### PR TITLE
fix: Punnycode -> Punycode

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -7,7 +7,7 @@
         "state": {
           "branch": null,
           "revision": "4356ec54e073741449640d3d50a1fd24fd1e1b8b",
-          "version": "2.1.0"
+          "version": "2.1.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             dependencies: ["ContentBlockerConverter", "Shared", "ArgumentParser"]),
         .target(
             name: "ContentBlockerConverter",
-            dependencies: ["Punnycode", "Shared"]),
+            dependencies: ["Punycode", "Shared"]),
         .target(
             name: "ContentBlockerEngine",
             dependencies: ["ContentBlockerConverter", "Shared"]),


### PR DESCRIPTION
fixes package name in `Package.swift`, which prevents from resolving package graph