### PR TITLE
Support $method via request-method trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Adopted `$method` modifier by using Safari's `request-method` trigger field (Safari 26+): [#88]
+
 [unreleased]: https://github.com/AdguardTeam/SafariConverterLib/compare/v4.0.4...HEAD
+[#88]: https://github.com/AdguardTeam/SafariConverterLib/issues/88
 
 ## [v4.0.4]
 

--- a/Sources/ContentBlockerConverter/Compiler/BlockerEntry.swift
+++ b/Sources/ContentBlockerConverter/Compiler/BlockerEntry.swift
@@ -43,6 +43,7 @@ public struct BlockerEntry: Codable, Equatable, CustomStringConvertible {
             unlessDomain: [String]? = nil,
             loadType: [String]? = nil,
             resourceType: [String]? = nil,
+            requestMethod: String? = nil,
             caseSensitive: Bool? = nil,
             loadContext: [String]? = nil
         ) {
@@ -51,6 +52,7 @@ public struct BlockerEntry: Codable, Equatable, CustomStringConvertible {
             self.unlessDomain = unlessDomain
             self.loadType = loadType
             self.resourceType = resourceType
+            self.requestMethod = requestMethod
             self.caseSensitive = caseSensitive
             self.loadContext = loadContext
         }
@@ -60,6 +62,7 @@ public struct BlockerEntry: Codable, Equatable, CustomStringConvertible {
         public var unlessDomain: [String]?
         public var loadType: [String]?
         public var resourceType: [String]?
+        public var requestMethod: String?
         public var caseSensitive: Bool?
         public var loadContext: [String]?
 
@@ -70,6 +73,7 @@ public struct BlockerEntry: Codable, Equatable, CustomStringConvertible {
             case unlessDomain = "unless-domain"
             case loadType = "load-type"
             case resourceType = "resource-type"
+            case requestMethod = "request-method"
             case caseSensitive = "url-filter-is-case-sensitive"
             case loadContext = "load-context"
         }
@@ -78,8 +82,8 @@ public struct BlockerEntry: Codable, Equatable, CustomStringConvertible {
         public static func == (lhs: Trigger, rhs: Trigger) -> Bool {
             return lhs.ifDomain == rhs.ifDomain && lhs.urlFilter == rhs.urlFilter
                 && lhs.unlessDomain == rhs.unlessDomain && lhs.loadType == rhs.loadType
-                && lhs.resourceType == rhs.resourceType && lhs.caseSensitive == rhs.caseSensitive
-                && lhs.loadContext == rhs.loadContext
+                && lhs.resourceType == rhs.resourceType && lhs.requestMethod == rhs.requestMethod
+                && lhs.caseSensitive == rhs.caseSensitive && lhs.loadContext == rhs.loadContext
         }
     }
 

--- a/Sources/ContentBlockerConverter/Compiler/BlockerEntryEncoder.swift
+++ b/Sources/ContentBlockerConverter/Compiler/BlockerEntryEncoder.swift
@@ -120,6 +120,12 @@ class BlockerEntryEncoder {
             result.append(loadContext.encodeToJSON())
         }
 
+        if let requestMethod = trigger.requestMethod {
+            result.append(",\"request-method\":\"")
+            result.append(requestMethod.escapeForJSON())
+            result.append("\"")
+        }
+
         if let ifDomain = trigger.ifDomain {
             result.append(",\"if-domain\":")
             result.append(ifDomain.encodeToJSON(escape: true))

--- a/Sources/ContentBlockerConverter/Compiler/BlockerEntryFactory.swift
+++ b/Sources/ContentBlockerConverter/Compiler/BlockerEntryFactory.swift
@@ -57,9 +57,7 @@ class BlockerEntryFactory {
     func createBlockerEntries(rule: Rule) -> [BlockerEntry]? {
         do {
             if let rule = rule as? NetworkRule {
-                let entry = try convertNetworkRule(rule: rule)
-
-                return [entry]
+                return try convertNetworkRuleEntries(rule: rule)
             }
 
             if let rule = rule as? CosmeticRule {
@@ -82,13 +80,27 @@ class BlockerEntryFactory {
         return nil
     }
 
+    private func convertNetworkRuleEntries(rule: NetworkRule) throws -> [BlockerEntry] {
+        if rule.requestMethods.isEmpty {
+            return [try convertNetworkRule(rule: rule, requestMethod: nil)]
+        }
+
+        if !self.version.isSafari26orGreater() {
+            throw ConversionError.unsupportedRule(message: "$method is not supported")
+        }
+
+        return try rule.requestMethods.map { method in
+            try convertNetworkRule(rule: rule, requestMethod: method)
+        }
+    }
+
     /// Converts a network rule into a Safari content blocking rule.
     ///
     /// - Parameters:
     ///   - rule: Network rule to convert.
     /// - Returns: Safari content blocker entry.
     /// - Throws: `ConversionError` if the rule cannot be converted.
-    private func convertNetworkRule(rule: NetworkRule) throws -> BlockerEntry {
+    private func convertNetworkRule(rule: NetworkRule, requestMethod: String?) throws -> BlockerEntry {
         let urlFilter = try createUrlFilterString(rule: rule)
 
         var trigger = BlockerEntry.Trigger(urlFilter: urlFilter)
@@ -101,6 +113,10 @@ class BlockerEntryFactory {
         try addDomainOptions(rule: rule, trigger: &trigger)
 
         try updateTriggerForDocumentLevelExceptionRules(rule: rule, trigger: &trigger)
+
+        if let requestMethod {
+            trigger.requestMethod = requestMethod
+        }
 
         let result = BlockerEntry(trigger: trigger, action: action)
 

--- a/Sources/ContentBlockerConverter/Rules/SafariVersion.swift
+++ b/Sources/ContentBlockerConverter/Rules/SafariVersion.swift
@@ -79,6 +79,11 @@ public enum SafariVersion: CustomStringConvertible, CustomDebugStringConvertible
         return self.doubleValue >= SafariVersion.safari16_4.doubleValue
     }
 
+    /// Starting from Safari 26 content blockers add new trigger fields like `request-method`.
+    public func isSafari26orGreater() -> Bool {
+        return self.doubleValue >= 26.0
+    }
+
     /// Detects the Safari version based on the current OS version.
     /// - Returns: The detected SafariVersion based on the OS.
     public static func autodetect() -> SafariVersion {

--- a/Tests/ContentBlockerConverterTests/Compiler/BlockerEntryEncoderTests.swift
+++ b/Tests/ContentBlockerConverterTests/Compiler/BlockerEntryEncoderTests.swift
@@ -28,4 +28,23 @@ final class BlockerEntryEncoderTests: XCTestCase {
             )
         }
     }
+
+    func testRequestMethod() throws {
+        let safari26 = SafariVersion(26.0)
+        let converter = BlockerEntryFactory(
+            errorsCounter: ErrorsCounter(),
+            version: safari26
+        )
+        let rule = try NetworkRule(ruleText: "||example.com/path$domain=test.com,method=post", for: safari26)
+
+        let entries = converter.createBlockerEntries(rule: rule)
+
+        if let entries = entries {
+            let (result, _) = encoder.encode(entries: entries)
+            XCTAssertEqual(
+                result,
+                #"[{"trigger":{"url-filter":"^[^:]+://+([^:/]+\\.)?example\\.com\\/path","request-method":"post","if-domain":["*test.com"]},"action":{"type":"block"}}]"#
+            )
+        }
+    }
 }

--- a/Tests/ContentBlockerConverterTests/Compiler/BlockerEntryFactoryTests.swift
+++ b/Tests/ContentBlockerConverterTests/Compiler/BlockerEntryFactoryTests.swift
@@ -128,6 +128,49 @@ final class BlockerEntryFactoryTests: XCTestCase {
         }
     }
 
+    func testSafari26RequestMethod() {
+        let testCases: [TestCase] = [
+            TestCase(
+                ruleText: "||example.com/path$domain=test.com,method=post",
+                version: SafariVersion(26.0),
+                expectedEntry: BlockerEntry(
+                    trigger: BlockerEntry.Trigger(
+                        ifDomain: ["*test.com"],
+                        urlFilter: #"^[^:]+://+([^:/]+\.)?example\.com\/path"#,
+                        requestMethod: "post"
+                    ),
+                    action: BlockerEntry.Action(type: "block")
+                )
+            ),
+            TestCase(
+                ruleText: "||example.com/path$domain=test.com,method=get|post",
+                version: SafariVersion(26.0),
+                expectedEntries: [
+                    BlockerEntry(
+                        trigger: BlockerEntry.Trigger(
+                            ifDomain: ["*test.com"],
+                            urlFilter: #"^[^:]+://+([^:/]+\.)?example\.com\/path"#,
+                            requestMethod: "get"
+                        ),
+                        action: BlockerEntry.Action(type: "block")
+                    ),
+                    BlockerEntry(
+                        trigger: BlockerEntry.Trigger(
+                            ifDomain: ["*test.com"],
+                            urlFilter: #"^[^:]+://+([^:/]+\.)?example\.com\/path"#,
+                            requestMethod: "post"
+                        ),
+                        action: BlockerEntry.Action(type: "block")
+                    ),
+                ]
+            ),
+        ]
+
+        for testCase in testCases {
+            runTest(testCase)
+        }
+    }
+
     // MARK: - Third-party
 
     func testThirdPartyRules() {

--- a/Tests/ContentBlockerConverterTests/Rules/SafariVersionTests.swift
+++ b/Tests/ContentBlockerConverterTests/Rules/SafariVersionTests.swift
@@ -10,18 +10,21 @@ final class SafariVersionTests: XCTestCase {
         XCTAssertEqual(safariVersionResolved, .safari13)
         XCTAssertFalse(safariVersionResolved.isSafari15orGreater())
         XCTAssertFalse(safariVersionResolved.isSafari16_4orGreater())
+        XCTAssertFalse(safariVersionResolved.isSafari26orGreater())
 
         safariVersion = 14.0
         safariVersionResolved = SafariVersion(safariVersion)
         XCTAssertEqual(safariVersionResolved, .safari14)
         XCTAssertFalse(safariVersionResolved.isSafari15orGreater())
         XCTAssertFalse(safariVersionResolved.isSafari16_4orGreater())
+        XCTAssertFalse(safariVersionResolved.isSafari26orGreater())
 
         safariVersion = 15.0
         safariVersionResolved = SafariVersion(safariVersion)
         XCTAssertEqual(safariVersionResolved, .safari15)
         XCTAssertTrue(safariVersionResolved.isSafari15orGreater())
         XCTAssertFalse(safariVersionResolved.isSafari16_4orGreater())
+        XCTAssertFalse(safariVersionResolved.isSafari26orGreater())
 
         safariVersion = 15.1
         safariVersionResolved = SafariVersion(safariVersion)
@@ -29,30 +32,42 @@ final class SafariVersionTests: XCTestCase {
         XCTAssertEqual(safariVersionResolved, .safari15)
         XCTAssertTrue(safariVersionResolved.isSafari15orGreater())
         XCTAssertFalse(safariVersionResolved.isSafari16_4orGreater())
+        XCTAssertFalse(safariVersionResolved.isSafari26orGreater())
 
         safariVersion = 16.0
         safariVersionResolved = SafariVersion(safariVersion)
         XCTAssertEqual(safariVersionResolved, .safari16)
         XCTAssertTrue(safariVersionResolved.isSafari15orGreater())
         XCTAssertFalse(safariVersionResolved.isSafari16_4orGreater())
+        XCTAssertFalse(safariVersionResolved.isSafari26orGreater())
 
         safariVersion = 16.2
         safariVersionResolved = SafariVersion(safariVersion)
         XCTAssertEqual(safariVersionResolved, .safari16)
         XCTAssertTrue(safariVersionResolved.isSafari15orGreater())
         XCTAssertFalse(safariVersionResolved.isSafari16_4orGreater())
+        XCTAssertFalse(safariVersionResolved.isSafari26orGreater())
 
         safariVersion = 16.4
         safariVersionResolved = SafariVersion(safariVersion)
         XCTAssertEqual(safariVersionResolved, .safari16_4)
         XCTAssertTrue(safariVersionResolved.isSafari15orGreater())
         XCTAssertTrue(safariVersionResolved.isSafari16_4orGreater())
+        XCTAssertFalse(safariVersionResolved.isSafari26orGreater())
 
         safariVersion = 17
         safariVersionResolved = SafariVersion(safariVersion)
         XCTAssertEqual(safariVersionResolved, .safari16_4Plus(safariVersion))
         XCTAssertTrue(safariVersionResolved.isSafari15orGreater())
         XCTAssertTrue(safariVersionResolved.isSafari16_4orGreater())
+        XCTAssertFalse(safariVersionResolved.isSafari26orGreater())
+
+        safariVersion = 26
+        safariVersionResolved = SafariVersion(safariVersion)
+        XCTAssertEqual(safariVersionResolved, .safari16_4Plus(safariVersion))
+        XCTAssertTrue(safariVersionResolved.isSafari15orGreater())
+        XCTAssertTrue(safariVersionResolved.isSafari16_4orGreater())
+        XCTAssertTrue(safariVersionResolved.isSafari26orGreater())
     }
 
     func testSafariVersionUnsupportedVersion() {
@@ -61,11 +76,13 @@ final class SafariVersionTests: XCTestCase {
         XCTAssertEqual(safariVersionResolved, .safari13)
         XCTAssertFalse(safariVersionResolved.isSafari15orGreater())
         XCTAssertFalse(safariVersionResolved.isSafari16_4orGreater())
+        XCTAssertFalse(safariVersionResolved.isSafari26orGreater())
 
         safariVersion = 35.0
         safariVersionResolved = SafariVersion(safariVersion)
         XCTAssertEqual(safariVersionResolved, .safari16_4Plus(safariVersion))
         XCTAssertTrue(safariVersionResolved.isSafari15orGreater())
         XCTAssertTrue(safariVersionResolved.isSafari16_4orGreater())
+        XCTAssertTrue(safariVersionResolved.isSafari26orGreater())
     }
 }


### PR DESCRIPTION
Safari 26 adds the `request-method` content blocker trigger field. This PR adopts AdGuard's `$method` modifier by emitting Safari content blocker rules with request-method when converting for Safari 26+ (addresses #88).

## Changes:
- Parse `$method=...` modifier on network rules and validate supported methods.
- For Safari 26+, generate one blocker entry per method value (e.g. `get|post` => 2 entries) using `trigger.request-method`.
- For Safari < 26, treat `$method` as unsupported.
- Add unit tests and a changelog entry.