### PR TITLE
Support domain wildcards/regex via if-frame-url triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support domain wildcards (`domain.*`) and domain regexes on Safari 26+ using `if-frame-url`/`unless-frame-url`: [#100]
+
 [unreleased]: https://github.com/AdguardTeam/SafariConverterLib/compare/v4.1.0...HEAD
+[#100]: https://github.com/AdguardTeam/SafariConverterLib/issues/100
 
 ## [v4.1.0]
 

--- a/README.md
+++ b/README.md
@@ -155,11 +155,13 @@ certainly supports the most important types of those rules.
     `$domain=example.org|~sub.example.org`). Please upvote the
     [feature request][webkitmixeddomainsissue] to WebKit to lift this
     limitation.
-    - "Any TLD" (i.e. `domain.*`) is not fully supported. In the current
-    implementation the converter just replaces `.*` with top 100 popular TLDs.
-    This implementation will be improved [in the future][iftopurlissue].
-    - Using regular expressions in `$domain` is not supported, but it also will
-    be improved [in the future][iftopurlissue].
+    - "Any TLD" (i.e. `domain.*`):
+        - Safari 26+: supported via `if-frame-url`/`unless-frame-url`.
+        - Safari < 26: the converter replaces `.*` with top 100 popular TLDs.
+    - Using regular expressions in `$domain` (i.e. `$domain=/regexp/`):
+        - Safari 26+: supported via `if-frame-url`/`unless-frame-url` (limited to
+          regex that is [supported by Safari][safariregex]).
+        - Safari < 26: not supported.
 
 - `$denyallow` - this modifier is supported via converting `$denyallow` rule to
   a set of rules (one blocking rule + several unblocking rules).
@@ -239,7 +241,6 @@ certainly supports the most important types of those rules.
 [safariregex]: https://developer.apple.com/documentation/safariservices/creating-a-content-blocker#Capture-URLs-by-pattern
 [webkitmixeddomainsissue]: https://bugs.webkit.org/show_bug.cgi?id=226076
 [domainmodifier]: https://adguard.com/kb/general/ad-filtering/create-own-filters/#domain-modifier
-[iftopurlissue]: https://github.com/AdguardTeam/SafariConverterLib/issues/20#issuecomment-2532818732
 [#69]: https://github.com/AdguardTeam/SafariConverterLib/issues/69
 [#70]: https://github.com/AdguardTeam/SafariConverterLib/issues/70
 [#71]: https://github.com/AdguardTeam/SafariConverterLib/issues/71
@@ -289,11 +290,13 @@ additional extension.
 #### Limitations of cosmetic rules
 
 - Specifying domains is subject to limitations:
-    - "Any TLD" (i.e. `domain.*`) is not fully supported. In the current
-    implementation the converter just replaces `.*` with top 100 popular TLDs.
-    This implementation will be improved [in the future][iftopurlissue].
-    - Using regular expressions in `$domain` is not supported, but it also will
-    be improved [in the future][iftopurlissue].
+    - "Any TLD" (i.e. `domain.*`):
+        - Safari 26+: supported via `if-frame-url`/`unless-frame-url`.
+        - Safari < 26: the converter replaces `.*` with top 100 popular TLDs.
+    - Using regular expressions in `$domain` (i.e. `$domain=/regexp/`):
+        - Safari 26+: supported via `if-frame-url`/`unless-frame-url` (limited to
+          regex that is [supported by Safari][safariregex]).
+        - Safari < 26: not supported.
 
 - CSS exception rules (`#@#`) are supported with limitations:
     - The same limitations for specifying domains as with other cosmetic rules.

--- a/Sources/ContentBlockerConverter/Compiler/BlockerEntry.swift
+++ b/Sources/ContentBlockerConverter/Compiler/BlockerEntry.swift
@@ -39,8 +39,10 @@ public struct BlockerEntry: Codable, Equatable, CustomStringConvertible {
     public struct Trigger: Codable, Equatable {
         public init(
             ifDomain: [String]? = nil,
+            ifFrameUrl: [String]? = nil,
             urlFilter: String? = nil,
             unlessDomain: [String]? = nil,
+            unlessFrameUrl: [String]? = nil,
             loadType: [String]? = nil,
             resourceType: [String]? = nil,
             requestMethod: String? = nil,
@@ -48,8 +50,10 @@ public struct BlockerEntry: Codable, Equatable, CustomStringConvertible {
             loadContext: [String]? = nil
         ) {
             self.ifDomain = ifDomain
+            self.ifFrameUrl = ifFrameUrl
             self.urlFilter = urlFilter
             self.unlessDomain = unlessDomain
+            self.unlessFrameUrl = unlessFrameUrl
             self.loadType = loadType
             self.resourceType = resourceType
             self.requestMethod = requestMethod
@@ -58,8 +62,10 @@ public struct BlockerEntry: Codable, Equatable, CustomStringConvertible {
         }
 
         public var ifDomain: [String]?
+        public var ifFrameUrl: [String]?
         public var urlFilter: String?
         public var unlessDomain: [String]?
+        public var unlessFrameUrl: [String]?
         public var loadType: [String]?
         public var resourceType: [String]?
         public var requestMethod: String?
@@ -69,8 +75,10 @@ public struct BlockerEntry: Codable, Equatable, CustomStringConvertible {
         // swiftlint:disable:next nesting
         enum CodingKeys: String, CodingKey {
             case ifDomain = "if-domain"
+            case ifFrameUrl = "if-frame-url"
             case urlFilter = "url-filter"
             case unlessDomain = "unless-domain"
+            case unlessFrameUrl = "unless-frame-url"
             case loadType = "load-type"
             case resourceType = "resource-type"
             case requestMethod = "request-method"
@@ -81,9 +89,14 @@ public struct BlockerEntry: Codable, Equatable, CustomStringConvertible {
         // Custom Equatable implementation
         public static func == (lhs: Trigger, rhs: Trigger) -> Bool {
             return lhs.ifDomain == rhs.ifDomain && lhs.urlFilter == rhs.urlFilter
-                && lhs.unlessDomain == rhs.unlessDomain && lhs.loadType == rhs.loadType
-                && lhs.resourceType == rhs.resourceType && lhs.requestMethod == rhs.requestMethod
-                && lhs.caseSensitive == rhs.caseSensitive && lhs.loadContext == rhs.loadContext
+                && lhs.ifFrameUrl == rhs.ifFrameUrl
+                && lhs.unlessDomain == rhs.unlessDomain
+                && lhs.unlessFrameUrl == rhs.unlessFrameUrl
+                && lhs.loadType == rhs.loadType
+                && lhs.resourceType == rhs.resourceType
+                && lhs.requestMethod == rhs.requestMethod
+                && lhs.caseSensitive == rhs.caseSensitive
+                && lhs.loadContext == rhs.loadContext
         }
     }
 

--- a/Sources/ContentBlockerConverter/Compiler/BlockerEntryEncoder.swift
+++ b/Sources/ContentBlockerConverter/Compiler/BlockerEntryEncoder.swift
@@ -126,6 +126,16 @@ class BlockerEntryEncoder {
             result.append("\"")
         }
 
+        if let ifFrameUrl = trigger.ifFrameUrl {
+            result.append(",\"if-frame-url\":")
+            result.append(ifFrameUrl.encodeToJSON(escape: true))
+        }
+
+        if let unlessFrameUrl = trigger.unlessFrameUrl {
+            result.append(",\"unless-frame-url\":")
+            result.append(unlessFrameUrl.encodeToJSON(escape: true))
+        }
+
         if let ifDomain = trigger.ifDomain {
             result.append(",\"if-domain\":")
             result.append(ifDomain.encodeToJSON(escape: true))

--- a/Sources/ContentBlockerConverter/Compiler/BlockerEntryFactory.swift
+++ b/Sources/ContentBlockerConverter/Compiler/BlockerEntryFactory.swift
@@ -99,7 +99,12 @@ class BlockerEntryFactory {
         entries.reserveCapacity(rule.requestMethods.count)
 
         for method in rule.requestMethods {
-            entries.append(contentsOf: try convertNetworkRuleEntries(rule: rule, requestMethod: method))
+            entries.append(
+                contentsOf: try convertNetworkRuleEntries(
+                    rule: rule,
+                    requestMethod: method
+                )
+            )
         }
         return entries
     }

--- a/Sources/ContentBlockerConverter/Rules/CosmeticRule.swift
+++ b/Sources/ContentBlockerConverter/Rules/CosmeticRule.swift
@@ -339,7 +339,11 @@ public class CosmeticRule: Rule {
             if let remainingDomains = try parseCosmeticOptions(domains: domains, version: version),
                 !remainingDomains.isEmpty
             {
-                try addDomains(domainsStr: remainingDomains, separator: Chars.COMMA, version: version)
+                try addDomains(
+                    domainsStr: remainingDomains,
+                    separator: Chars.COMMA,
+                    version: version
+                )
             }
         } else {
             try addDomains(domainsStr: domains, separator: Chars.COMMA, version: version)

--- a/Sources/ContentBlockerConverter/Rules/CosmeticRule.swift
+++ b/Sources/ContentBlockerConverter/Rules/CosmeticRule.swift
@@ -130,7 +130,7 @@ public class CosmeticRule: Rule {
             // Support for *## for generic rules
             // https://github.com/AdguardTeam/SafariConverterLib/issues/11
             if !(domains.utf8.count == 1 && domains.utf8.first == Chars.WILDCARD) {
-                try setCosmeticRuleDomains(domains: domains)
+                try setCosmeticRuleDomains(domains: domains, version: version)
             }
         }
 
@@ -258,13 +258,13 @@ public class CosmeticRule: Rule {
     }
 
     /// Parses a single cosmetic option.
-    private func parseOption(name: String, value: String) throws {
+    private func parseOption(name: String, value: String, version: SafariVersion) throws {
         switch name {
         case "domain", "from":
             if value.isEmpty {
                 throw SyntaxError.invalidModifier(message: "$domain modifier cannot be empty")
             }
-            try addDomains(domainsStr: value, separator: Chars.PIPE)
+            try addDomains(domainsStr: value, separator: Chars.PIPE, version: version)
         case "path":
             if value.isEmpty {
                 throw SyntaxError.invalidRule(message: "$path modifier cannot be empty")
@@ -299,7 +299,7 @@ public class CosmeticRule: Rule {
     /// https://adguard.com/kb/general/ad-filtering/create-own-filters/#non-basic-rules-modifiers
     ///
     /// - Returns: what's left of the domains string or nil if the rule only has cosmetic options.
-    private func parseCosmeticOptions(domains: String) throws -> String? {
+    private func parseCosmeticOptions(domains: String, version: SafariVersion) throws -> String? {
         let startIndex = domains.utf8.index(domains.utf8.startIndex, offsetBy: 2)
         guard let endIndex = domains.utf8.lastIndex(of: Chars.SQUARE_BRACKET_CLOSE) else {
             throw SyntaxError.invalidModifier(message: "Invalid option format")
@@ -321,7 +321,7 @@ public class CosmeticRule: Rule {
                 optionValue = String(option[option.utf8.index(after: valueIndex)...])
             }
 
-            try parseOption(name: optionName, value: optionValue)
+            try parseOption(name: optionName, value: optionValue, version: version)
         }
 
         // Parse what's left after the options string.
@@ -334,15 +334,15 @@ public class CosmeticRule: Rule {
         return nil
     }
 
-    func setCosmeticRuleDomains(domains: String) throws {
+    func setCosmeticRuleDomains(domains: String, version: SafariVersion) throws {
         if domains.utf8.first == Chars.SQUARE_BRACKET_OPEN {
-            if let remainingDomains = try parseCosmeticOptions(domains: domains),
+            if let remainingDomains = try parseCosmeticOptions(domains: domains, version: version),
                 !remainingDomains.isEmpty
             {
-                try addDomains(domainsStr: remainingDomains, separator: Chars.COMMA)
+                try addDomains(domainsStr: remainingDomains, separator: Chars.COMMA, version: version)
             }
         } else {
-            try addDomains(domainsStr: domains, separator: Chars.COMMA)
+            try addDomains(domainsStr: domains, separator: Chars.COMMA, version: version)
         }
     }
 }

--- a/Sources/ContentBlockerConverter/Rules/NetworkRule.swift
+++ b/Sources/ContentBlockerConverter/Rules/NetworkRule.swift
@@ -337,9 +337,9 @@ public class NetworkRule: Rule {
         case "badfilter":
             isBadfilter = true
         case "domain", "from":
+            try setNetworkRuleDomains(domains: optionValue, version: version)
         case "method":
             try setRequestMethods(methods: optionValue)
-            try setNetworkRuleDomains(domains: optionValue, version: version)
         case "elemhide", "ehide":
             try setOptionEnabled(option: .elemhide, value: true)
         case "generichide", "ghide":

--- a/Sources/ContentBlockerConverter/Rules/NetworkRule.swift
+++ b/Sources/ContentBlockerConverter/Rules/NetworkRule.swift
@@ -174,12 +174,12 @@ public class NetworkRule: Rule {
     }
 
     /// Sets rule domains from the $domain modifier.
-    private func setNetworkRuleDomains(domains: String) throws {
+    private func setNetworkRuleDomains(domains: String, version: SafariVersion) throws {
         if domains.isEmpty {
             throw SyntaxError.invalidModifier(message: "$domain cannot be empty")
         }
 
-        try addDomains(domainsStr: domains, separator: Chars.PIPE)
+        try addDomains(domainsStr: domains, separator: Chars.PIPE, version: version)
     }
 
     /// Supported HTTP request methods for the `$method` modifier.
@@ -337,9 +337,9 @@ public class NetworkRule: Rule {
         case "badfilter":
             isBadfilter = true
         case "domain", "from":
-            try setNetworkRuleDomains(domains: optionValue)
         case "method":
             try setRequestMethods(methods: optionValue)
+            try setNetworkRuleDomains(domains: optionValue, version: version)
         case "elemhide", "ehide":
             try setOptionEnabled(option: .elemhide, value: true)
         case "generichide", "ghide":

--- a/Sources/ContentBlockerConverter/Rules/Rule.swift
+++ b/Sources/ContentBlockerConverter/Rules/Rule.swift
@@ -33,7 +33,10 @@ public class Rule {
         var nonASCIIFound = false
         var restricted = false
         var insideRegex = false
-        var previousCharWasBackslash = false
+        // Number of consecutive backslashes immediately preceding `currentIndex`.
+        // Used to detect whether a slash is escaped inside a regex domain (odd count)
+        // or can terminate the regex (even count).
+        var precedingBackslashCount = 0
 
         /// Creates domain string from `current` buffer and adds it to the corresponding list.
         ///
@@ -98,8 +101,8 @@ public class Rule {
                 insideRegex = true
             }
 
-            if insideRegex && char == Chars.SLASH && !previousCharWasBackslash
-                && currentIndex != domainStartIndex
+            if insideRegex && char == Chars.SLASH && currentIndex != domainStartIndex
+                && (precedingBackslashCount % 2 == 0)
             {
                 // Closing slash of the regex domain.
                 insideRegex = false
@@ -136,10 +139,10 @@ public class Rule {
                 }
             }
 
-            if previousCharWasBackslash {
-                previousCharWasBackslash = false
+            if char == Chars.BACKSLASH {
+                precedingBackslashCount += 1
             } else {
-                previousCharWasBackslash = char == Chars.BACKSLASH
+                precedingBackslashCount = 0
             }
 
             currentIndex = utf8.index(after: currentIndex)

--- a/Sources/ContentBlockerConverter/Rules/SafariVersion.swift
+++ b/Sources/ContentBlockerConverter/Rules/SafariVersion.swift
@@ -84,8 +84,8 @@ public enum SafariVersion: CustomStringConvertible, CustomDebugStringConvertible
         return self.doubleValue >= SafariVersion.safari16_4.doubleValue
     }
 
-    /// Starting from Safari 26 content blockers add new trigger fields like
-    /// `request-method`.
+    /// Starting from Safari 26 content blockers add new trigger fields like `request-method`,
+    /// `if-frame-url`, and `unless-frame-url`.
     public func isSafari26orGreater() -> Bool {
         return self.doubleValue >= SafariVersion.safari26.doubleValue
     }

--- a/Tests/ContentBlockerConverterTests/Compiler/BlockerEntryEncoderTests.swift
+++ b/Tests/ContentBlockerConverterTests/Compiler/BlockerEntryEncoderTests.swift
@@ -49,4 +49,22 @@ final class BlockerEntryEncoderTests: XCTestCase {
             )
         }
     }
+
+    func testFrameUrlEntry() throws {
+        let converter = BlockerEntryFactory(
+            errorsCounter: ErrorsCounter(),
+            version: SafariVersion.safari26
+        )
+        let rule = try NetworkRule(ruleText: "||example.com/path$domain=test.*")
+
+        let entries = converter.createBlockerEntries(rule: rule)
+
+        if let entries = entries {
+            let (result, _) = encoder.encode(entries: entries)
+            XCTAssertEqual(
+                result,
+                #"[{"trigger":{"url-filter":"^[^:]+://+([^:/]+\\.)?example\\.com\\/path","if-frame-url":["^[^:]+://+([^:/]+\\.)?test\\.[^/:]+(?:[/:?#]|$)"]},"action":{"type":"block"}}]"#
+            )
+        }
+    }
 }

--- a/Tests/ContentBlockerConverterTests/Compiler/BlockerEntryEncoderTests.swift
+++ b/Tests/ContentBlockerConverterTests/Compiler/BlockerEntryEncoderTests.swift
@@ -63,7 +63,7 @@ final class BlockerEntryEncoderTests: XCTestCase {
             let (result, _) = encoder.encode(entries: entries)
             XCTAssertEqual(
                 result,
-                #"[{"trigger":{"url-filter":"^[^:]+://+([^:/]+\\.)?example\\.com\\/path","if-frame-url":["^[^:]+://+([^:/]+\\.)?test\\.[^/:]+(?:[/:?#]|$)"]},"action":{"type":"block"}}]"#
+                #"[{"trigger":{"url-filter":"^[^:]+://+([^:/]+\\.)?example\\.com\\/path","if-frame-url":["^[^:]+://+([^:/]+\\.)?test\\.[^/:]+([/:?#].*)?$"]},"action":{"type":"block"}}]"#
             )
         }
     }

--- a/Tests/ContentBlockerConverterTests/Compiler/BlockerEntryFactoryTests.swift
+++ b/Tests/ContentBlockerConverterTests/Compiler/BlockerEntryFactoryTests.swift
@@ -128,6 +128,81 @@ final class BlockerEntryFactoryTests: XCTestCase {
         }
     }
 
+    // MARK: - Safari 26 domains
+
+    func testSafari26FrameUrlDomainOptions() {
+        let testCases: [TestCase] = [
+            TestCase(
+                ruleText: "||example.com/path$domain=test.com",
+                version: SafariVersion.safari26,
+                expectedEntry: BlockerEntry(
+                    trigger: BlockerEntry.Trigger(
+                        ifDomain: ["*test.com"],
+                        urlFilter: #"^[^:]+://+([^:/]+\.)?example\.com\/path"#
+                    ),
+                    action: BlockerEntry.Action(type: "block")
+                )
+            ),
+            TestCase(
+                ruleText: "||example.com/path$domain=test.*",
+                version: SafariVersion.safari26,
+                expectedEntry: BlockerEntry(
+                    trigger: BlockerEntry.Trigger(
+                        ifFrameUrl: [#"^[^:]+://+([^:/]+\.)?test\.[^/:]+(?:[/:?#]|$)"#],
+                        urlFilter: #"^[^:]+://+([^:/]+\.)?example\.com\/path"#
+                    ),
+                    action: BlockerEntry.Action(type: "block")
+                )
+            ),
+            TestCase(
+                ruleText: "||example.com/path$domain=test.com|test.*",
+                version: SafariVersion.safari26,
+                expectedEntries: [
+                    BlockerEntry(
+                        trigger: BlockerEntry.Trigger(
+                            ifDomain: ["*test.com"],
+                            urlFilter: #"^[^:]+://+([^:/]+\.)?example\.com\/path"#
+                        ),
+                        action: BlockerEntry.Action(type: "block")
+                    ),
+                    BlockerEntry(
+                        trigger: BlockerEntry.Trigger(
+                            ifFrameUrl: [#"^[^:]+://+([^:/]+\.)?test\.[^/:]+(?:[/:?#]|$)"#],
+                            urlFilter: #"^[^:]+://+([^:/]+\.)?example\.com\/path"#
+                        ),
+                        action: BlockerEntry.Action(type: "block")
+                    ),
+                ]
+            ),
+            TestCase(
+                ruleText: "||example.com/path$domain=~test.*",
+                version: SafariVersion.safari26,
+                expectedEntry: BlockerEntry(
+                    trigger: BlockerEntry.Trigger(
+                        urlFilter: #"^[^:]+://+([^:/]+\.)?example\.com\/path"#,
+                        unlessFrameUrl: [#"^[^:]+://+([^:/]+\.)?test\.[^/:]+(?:[/:?#]|$)"#]
+                    ),
+                    action: BlockerEntry.Action(type: "block")
+                )
+            ),
+            TestCase(
+                ruleText: #"||example.com/path$domain=/test\.(com|net)/"#,
+                version: SafariVersion.safari26,
+                expectedEntry: BlockerEntry(
+                    trigger: BlockerEntry.Trigger(
+                        ifFrameUrl: [#"^[^:]+://+([^:/]+\.)?test\.(com|net)(?:[/:?#]|$)"#],
+                        urlFilter: #"^[^:]+://+([^:/]+\.)?example\.com\/path"#
+                    ),
+                    action: BlockerEntry.Action(type: "block")
+                )
+            ),
+        ]
+
+        for testCase in testCases {
+            runTest(testCase)
+        }
+    }
+
     // MARK: - Request methods
 
     func testRequestMethodRules() {

--- a/Tests/ContentBlockerConverterTests/Compiler/BlockerEntryFactoryTests.swift
+++ b/Tests/ContentBlockerConverterTests/Compiler/BlockerEntryFactoryTests.swift
@@ -148,7 +148,7 @@ final class BlockerEntryFactoryTests: XCTestCase {
                 version: SafariVersion.safari26,
                 expectedEntry: BlockerEntry(
                     trigger: BlockerEntry.Trigger(
-                        ifFrameUrl: [#"^[^:]+://+([^:/]+\.)?test\.[^/:]+(?:[/:?#]|$)"#],
+                        ifFrameUrl: [#"^[^:]+://+([^:/]+\.)?test\.[^/:]+([/:?#].*)?$"#],
                         urlFilter: #"^[^:]+://+([^:/]+\.)?example\.com\/path"#
                     ),
                     action: BlockerEntry.Action(type: "block")
@@ -167,7 +167,7 @@ final class BlockerEntryFactoryTests: XCTestCase {
                     ),
                     BlockerEntry(
                         trigger: BlockerEntry.Trigger(
-                            ifFrameUrl: [#"^[^:]+://+([^:/]+\.)?test\.[^/:]+(?:[/:?#]|$)"#],
+                            ifFrameUrl: [#"^[^:]+://+([^:/]+\.)?test\.[^/:]+([/:?#].*)?$"#],
                             urlFilter: #"^[^:]+://+([^:/]+\.)?example\.com\/path"#
                         ),
                         action: BlockerEntry.Action(type: "block")
@@ -180,17 +180,17 @@ final class BlockerEntryFactoryTests: XCTestCase {
                 expectedEntry: BlockerEntry(
                     trigger: BlockerEntry.Trigger(
                         urlFilter: #"^[^:]+://+([^:/]+\.)?example\.com\/path"#,
-                        unlessFrameUrl: [#"^[^:]+://+([^:/]+\.)?test\.[^/:]+(?:[/:?#]|$)"#]
+                        unlessFrameUrl: [#"^[^:]+://+([^:/]+\.)?test\.[^/:]+([/:?#].*)?$"#]
                     ),
                     action: BlockerEntry.Action(type: "block")
                 )
             ),
             TestCase(
-                ruleText: #"||example.com/path$domain=/test\.(com|net)/"#,
+                ruleText: #"||example.com/path$domain=/test\.[a-z]+/"#,
                 version: SafariVersion.safari26,
                 expectedEntry: BlockerEntry(
                     trigger: BlockerEntry.Trigger(
-                        ifFrameUrl: [#"^[^:]+://+([^:/]+\.)?test\.(com|net)(?:[/:?#]|$)"#],
+                        ifFrameUrl: [#"^[^:]+://+([^:/]+\.)?test\.[a-z]+([/:?#].*)?$"#],
                         urlFilter: #"^[^:]+://+([^:/]+\.)?example\.com\/path"#
                     ),
                     action: BlockerEntry.Action(type: "block")

--- a/Tests/ContentBlockerConverterTests/ContentBlockerConverterPerformanceTests.swift
+++ b/Tests/ContentBlockerConverterTests/ContentBlockerConverterPerformanceTests.swift
@@ -69,6 +69,14 @@ extension ContentBlockerConverterTests {
     /// - Swift: 6.2.3
     /// - Average execution time: ~0.924 sec
     ///
+    /// PR #115 performance check (Jan 6, 2026):
+    /// - Machine: Apple M3, 16GB RAM
+    /// - OS: macOS 26.2
+    /// - Swift: 6.2.3
+    /// - Before (upstream/master @ 8b2eab8): ~0.892 sec
+    /// - After (pr-frame-url-triggers @ 364e903): ~0.923 sec
+    /// - Difference: +~0.031 sec (~+3.5%)
+    ///
     /// To get your machine info: `system_profiler SPHardwareDataType`
     /// To get your macOS version: `sw_vers`
     /// To get your Swift version: `swift --version`

--- a/Tests/ContentBlockerConverterTests/ContentBlockerConverterPerformanceTests.swift
+++ b/Tests/ContentBlockerConverterTests/ContentBlockerConverterPerformanceTests.swift
@@ -69,14 +69,6 @@ extension ContentBlockerConverterTests {
     /// - Swift: 6.2.3
     /// - Average execution time: ~0.924 sec
     ///
-    /// PR #115 performance check (Jan 6, 2026):
-    /// - Machine: Apple M3, 16GB RAM
-    /// - OS: macOS 26.2
-    /// - Swift: 6.2.3
-    /// - Before (upstream/master @ 8b2eab8): ~0.892 sec
-    /// - After (pr-frame-url-triggers @ 364e903): ~0.923 sec
-    /// - Difference: +~0.031 sec (~+3.5%)
-    ///
     /// To get your machine info: `system_profiler SPHardwareDataType`
     /// To get your macOS version: `sw_vers`
     /// To get your Swift version: `swift --version`

--- a/Tests/ContentBlockerConverterTests/ContentBlockerConverterPerformanceTests.swift
+++ b/Tests/ContentBlockerConverterTests/ContentBlockerConverterPerformanceTests.swift
@@ -51,13 +51,6 @@ extension ContentBlockerConverterTests {
     }
 
     /// Benchmark test for convertArray performance.
-    ///
-    /// Baseline results (Dec 25, 2025):
-    /// - Machine: Apple M3, 16GB RAM
-    /// - OS: macOS 26.2
-    /// - Swift: 6.2.3
-    /// - Average execution time: ~0.924 sec
-    ///
     /// Baseline results (Aug 8, 2025):
     /// - Machine: MacBook Pro M4 Max, 48GB RAM
     /// - OS: macOS 26
@@ -69,6 +62,12 @@ extension ContentBlockerConverterTests {
     /// - OS: macOS 26
     /// - Swift: 6.2
     /// - Average execution time: ~0.787 sec
+    ///
+    /// Baseline results (Dec 25, 2025):
+    /// - Machine: Apple M3, 16GB RAM
+    /// - OS: macOS 26.2
+    /// - Swift: 6.2.3
+    /// - Average execution time: ~0.924 sec
     ///
     /// To get your machine info: `system_profiler SPHardwareDataType`
     /// To get your macOS version: `sw_vers`
@@ -99,12 +98,6 @@ extension ContentBlockerConverterTests {
 
     /// Benchmark test for handling $specifichide rules
     ///
-    /// Baseline results (Dec 25, 2025):
-    /// - Machine: Apple M3, 16GB RAM
-    /// - OS: macOS 26.2
-    /// - Swift: 6.2.3
-    /// - Average execution time: ~0.223 seconds
-    ///
     /// Baseline results (Aug 2025):
     /// - Machine: MacBook Pro M4 Max,48GB RAM
     /// - OS: macOS 26
@@ -117,6 +110,12 @@ extension ContentBlockerConverterTests {
     /// - Swift: 6.2
     /// - Average execution time: ~0.196 seconds
     /// - No considerable changes since the prev baseline so the diff is due to env changes.
+    ///
+    /// Baseline results (Dec 25, 2025):
+    /// - Machine: Apple M3, 16GB RAM
+    /// - OS: macOS 26.2
+    /// - Swift: 6.2.3
+    /// - Average execution time: ~0.223 seconds
     ///
     /// To get your machine info: `system_profiler SPHardwareDataType`
     /// To get your macOS version: `sw_vers`

--- a/Tests/ContentBlockerConverterTests/ContentBlockerConverterPerformanceTests.swift
+++ b/Tests/ContentBlockerConverterTests/ContentBlockerConverterPerformanceTests.swift
@@ -52,6 +52,12 @@ extension ContentBlockerConverterTests {
 
     /// Benchmark test for convertArray performance.
     ///
+    /// Baseline results (Dec 25, 2025):
+    /// - Machine: Apple M3, 16GB RAM
+    /// - OS: macOS 26.2
+    /// - Swift: 6.2.3
+    /// - Average execution time: ~0.924 sec
+    ///
     /// Baseline results (Aug 8, 2025):
     /// - Machine: MacBook Pro M4 Max, 48GB RAM
     /// - OS: macOS 26
@@ -92,6 +98,12 @@ extension ContentBlockerConverterTests {
     }
 
     /// Benchmark test for handling $specifichide rules
+    ///
+    /// Baseline results (Dec 25, 2025):
+    /// - Machine: Apple M3, 16GB RAM
+    /// - OS: macOS 26.2
+    /// - Swift: 6.2.3
+    /// - Average execution time: ~0.223 seconds
     ///
     /// Baseline results (Aug 2025):
     /// - Machine: MacBook Pro M4 Max,48GB RAM

--- a/Tests/ContentBlockerConverterTests/ContentBlockerConverterTests.swift
+++ b/Tests/ContentBlockerConverterTests/ContentBlockerConverterTests.swift
@@ -1484,7 +1484,7 @@ final class ContentBlockerConverterTests: XCTestCase {
                 rules: [
                     "||example.org$domain=/реклама\\.рф/"
                 ],
-                version: SafariVersion(26.0),
+                version: SafariVersion.safari26,
                 expectedSafariRulesJSON: ConversionResult.EMPTY_RESULT_JSON,
                 expectedSourceRulesCount: 1,
                 expectedSourceSafariCompatibleRulesCount: 1,

--- a/Tests/ContentBlockerConverterTests/ContentBlockerConverterTests.swift
+++ b/Tests/ContentBlockerConverterTests/ContentBlockerConverterTests.swift
@@ -1484,24 +1484,12 @@ final class ContentBlockerConverterTests: XCTestCase {
                 rules: [
                     "||example.org$domain=/реклама\\.рф/"
                 ],
-                expectedSafariRulesJSON: #"""
-                    [
-                      {
-                        "action" : {
-                          "type" : "block"
-                        },
-                        "trigger" : {
-                          "if-domain" : [
-                            "*xn--\/\\-7kcax4ahj5a.xn--\/-4tbm"
-                          ],
-                          "url-filter" : "^[^:]+:\/\/+([^:\/]+\\.)?example\\.org"
-                        }
-                      }
-                    ]
-                    """#,
+                version: SafariVersion(26.0),
+                expectedSafariRulesJSON: ConversionResult.EMPTY_RESULT_JSON,
                 expectedSourceRulesCount: 1,
                 expectedSourceSafariCompatibleRulesCount: 1,
-                expectedSafariRulesCount: 1
+                expectedSafariRulesCount: 0,
+                expectedErrorsCount: 1
             ),
         ]
 

--- a/Tests/ContentBlockerConverterTests/Rules/CosmeticRuleTests.swift
+++ b/Tests/ContentBlockerConverterTests/Rules/CosmeticRuleTests.swift
@@ -281,7 +281,8 @@ final class CosmeticRuleTests: XCTestCase {
         XCTAssertThrowsError(try CosmeticRule(ruleText: "jp,##.banner"))
         XCTAssertThrowsError(try CosmeticRule(ruleText: "jp,b##.banner"))
         XCTAssertThrowsError(try CosmeticRule(ruleText: "jp,~b##.banner"))
-        XCTAssertThrowsError(try CosmeticRule(ruleText: "com,/example/##.banner"))
+        XCTAssertThrowsError(try CosmeticRule(ruleText: "com,/example/##.banner", for: .safari16_4))
+        XCTAssertNoThrow(try CosmeticRule(ruleText: "com,/example/##.banner", for: .safari26))
         XCTAssertThrowsError(try CosmeticRule(ruleText: "[$path=/path]#@#.banner"))
     }
 

--- a/Tests/ContentBlockerConverterTests/Rules/NetworkRuleTests.swift
+++ b/Tests/ContentBlockerConverterTests/Rules/NetworkRuleTests.swift
@@ -219,7 +219,7 @@ final class NetworkRuleTests: XCTestCase {
             TestCase(
                 // Regex domain should terminate on a slash preceded by an even number of backslashes.
                 ruleText: #"||example.org^$domain=/test\\/|example.net"#,
-                version: SafariVersion(26.0),
+                version: SafariVersion.safari26,
                 expectedUrlRuleText: "||example.org^",
                 expectedUrlRegExpSource: "^[^:]+://+([^:/]+\\.)?example\\.org[/:]",
                 expectedPermittedDomains: [#"/test\\/"#, "example.net"]

--- a/Tests/ContentBlockerConverterTests/Rules/NetworkRuleTests.swift
+++ b/Tests/ContentBlockerConverterTests/Rules/NetworkRuleTests.swift
@@ -217,6 +217,14 @@ final class NetworkRuleTests: XCTestCase {
                 expectedRestrictedDomains: ["sub.example.org"]
             ),
             TestCase(
+                // Regex domain should terminate on a slash preceded by an even number of backslashes.
+                ruleText: #"||example.org^$domain=/test\\/|example.net"#,
+                version: SafariVersion(26.0),
+                expectedUrlRuleText: "||example.org^",
+                expectedUrlRegExpSource: "^[^:]+://+([^:/]+\\.)?example\\.org[/:]",
+                expectedPermittedDomains: [#"/test\\/"#, "example.net"]
+            ),
+            TestCase(
                 // Test $domain for TLD.
                 ruleText: "||example.org^$domain=jp|~co",
                 expectedUrlRuleText: "||example.org^",

--- a/Tests/ContentBlockerConverterTests/Rules/NetworkRuleTests.swift
+++ b/Tests/ContentBlockerConverterTests/Rules/NetworkRuleTests.swift
@@ -421,6 +421,8 @@ final class NetworkRuleTests: XCTestCase {
         XCTAssertThrowsError(try NetworkRule(ruleText: "||example.org^$domain=~e"))
         // $domain with regexes are not supported.
         XCTAssertThrowsError(try NetworkRule(ruleText: "||example.org^$domain=/example.org/"))
+        // Empty $domain regex should be rejected.
+        XCTAssertThrowsError(try NetworkRule(ruleText: "||example.org^$domain=//"))
         // $domain with regexes are not supported.
         XCTAssertThrowsError(
             try NetworkRule(ruleText: "||example.org^$domain=example.org|/test.com/")

--- a/Tests/ContentBlockerConverterTests/Rules/SimpleRegexTests.swift
+++ b/Tests/ContentBlockerConverterTests/Rules/SimpleRegexTests.swift
@@ -87,4 +87,26 @@ final class SimpleRegexTests: XCTestCase {
             )
         }
     }
+
+    func testUnescapeDomainRegex() {
+        let testCases: [(pattern: String, expected: String)] = [
+            (#"abc"#, #"abc"#),
+            (#"a\/b"#, #"a/b"#),
+            (#"a\|b"#, #"a|b"#),
+            (#"a\$b"#, #"a$b"#),
+            (#"a\,b"#, #"a,b"#),
+            (#"a\.b"#, #"a\.b"#),
+            (#"a\\/"#, #"a\/"#),
+            ("a\\", "a\\"),
+        ]
+
+        for (pattern, expected) in testCases {
+            let result = SimpleRegex.unescapeDomainRegex(pattern)
+            XCTAssertEqual(
+                result,
+                expected,
+                "Pattern '\(pattern)': expected unescapeDomainRegex to return \(expected), but got \(result)"
+            )
+        }
+    }
 }


### PR DESCRIPTION
Safari 26 adds `if-frame-url` / `unless-frame-url` triggers. This PR uses a hybrid approach to support `domain.*` and domain-regex values while keeping the fast path (`if-domain`/`unless-domain`) for plain domains to avoid unnecessary compilation overhead (addresses #100).

## Changes:
- For Safari 26+:
  - Keep using `if-domain` / `unless-domain` for plain domains.
  - Use `if-frame-url` / `unless-frame-url` only for:
     - TLD wildcards like `example.*`
     - Domain regexes like `/test\\.(com|net)/`
  - If a rule contains both plain + special domains, split it into multiple entries (one per trigger type) with the same action/other trigger fields.
- Update domain list parsing so `|` inside `/.../` domain regex doesn’t split the domain list.
- Preserve older-Safari third-party workaround behavior.
- Add unit tests and a changelog entry.